### PR TITLE
fix log messages order

### DIFF
--- a/lib/track.coffee
+++ b/lib/track.coffee
@@ -78,6 +78,8 @@ class Track
 		if !fs.existsSync @file.directory
 			mkdirp.sync @file.directory
 
+		Logger.Log "Downloading: #{@track.artist[0].name} - #{@track.name}", 1
+
 		@downloadCover()
 		@downloadFile()
 
@@ -96,8 +98,6 @@ class Track
 		Logger.Success "Cover downloaded: #{@track.artist[0].name} - #{@track.name}", 2
 
 	downloadFile: =>
-		Logger.Log "Downloading: #{@track.artist[0].name} - #{@track.name}", 1
-
 		d = domain.create()
 		d.on "error", (err) =>
 			Logger.Error "Error received: #{err}", 2

--- a/lib/track.js
+++ b/lib/track.js
@@ -114,6 +114,7 @@
       if (!fs.existsSync(this.file.directory)) {
         mkdirp.sync(this.file.directory);
       }
+      Logger.Log("Downloading: " + this.track.artist[0].name + " - " + this.track.name, 1);
       this.downloadCover();
       return this.downloadFile();
     };
@@ -138,7 +139,6 @@
 
     Track.prototype.downloadFile = function() {
       var d;
-      Logger.Log("Downloading: " + this.track.artist[0].name + " - " + this.track.name, 1);
       d = domain.create();
       d.on("error", (function(_this) {
         return function(err) {


### PR DESCRIPTION
Log messages were going on wrong order:
```
   - Cover downloaded: The Killers - Somebody Told Me
 - Downloading: The Killers - Somebody Told Me
   - Done: The Killers - Somebody Told Me
   - Cover downloaded: Symphony X - The End Of Innocence
 - Downloading: Symphony X - The End Of Innocence
   - Done: Symphony X - The End Of Innocence
```
Dunno how I didn't saw that.