### PR TITLE
Cleanup on unspecified error

### DIFF
--- a/lib/track.coffee
+++ b/lib/track.coffee
@@ -165,7 +165,8 @@ class Track
 					Logger.Error "Unable to download song. Continuing", 2
 					@callback?()
 			else
-				return @callback?()
+				@cleanDirs()
+				@callback?()
 		d.run =>
 			@out = fs.createWriteStream @file.path
 			try

--- a/lib/track.js
+++ b/lib/track.js
@@ -243,6 +243,7 @@
               return typeof _this.callback === "function" ? _this.callback() : void 0;
             }
           } else {
+            _this.cleanDirs();
             return typeof _this.callback === "function" ? _this.callback() : void 0;
           }
         };


### PR DESCRIPTION
This would render #35 obsolete, as it doesn't need a check and performs a cleanup in any unspecified kind of error (including that one).